### PR TITLE
DRAFT: Propagate timestamps from CallInfo to TestReport objects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -297,6 +297,7 @@ Ram Rachum
 Ran Benita
 Raphael Castaneda
 Raphael Pierzina
+Rafal Semik
 Raquel Alegre
 Ravi Chandra
 Robert Holt

--- a/changelog/10710.improvement.rst
+++ b/changelog/10710.improvement.rst
@@ -1,1 +1,1 @@
-Added ``start`` and ``stop`` timestamps to ``TestReport`` objects exported to --reportlog.
+Added ``start`` and ``stop`` timestamps to ``TestReport`` objects.

--- a/changelog/10710.improvement.rst
+++ b/changelog/10710.improvement.rst
@@ -1,0 +1,1 @@
+Added ``start`` and ``stop`` timestamps to ``TestReport`` objects exported to --reportlog.

--- a/src/_pytest/reports.py
+++ b/src/_pytest/reports.py
@@ -262,6 +262,8 @@ class TestReport(BaseReport):
         when: "Literal['setup', 'call', 'teardown']",
         sections: Iterable[Tuple[str, str]] = (),
         duration: float = 0,
+        start: float = 0,
+        stop: float = 0,
         user_properties: Optional[Iterable[Tuple[str, object]]] = None,
         **extra,
     ) -> None:
@@ -299,6 +301,11 @@ class TestReport(BaseReport):
         #: Time it took to run just the test.
         self.duration: float = duration
 
+        #: The system time when the call started, in seconds since the epoch.
+        self.start: float = start
+        #: The system time when the call ended, in seconds since the epoch.
+        self.stop: float = stop
+
         self.__dict__.update(extra)
 
     def __repr__(self) -> str:
@@ -317,6 +324,8 @@ class TestReport(BaseReport):
         # Remove "collect" from the Literal type -- only for collection calls.
         assert when != "collect"
         duration = call.duration
+        start = call.start
+        stop = call.stop
         keywords = {x: 1 for x in item.keywords}
         excinfo = call.excinfo
         sections = []
@@ -361,6 +370,8 @@ class TestReport(BaseReport):
             when,
             sections,
             duration,
+            start,
+            stop,
             user_properties=item.user_properties,
         )
 

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -6,6 +6,7 @@ from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionRepr
 from _pytest.config import Config
 from _pytest.pytester import Pytester
+from _pytest.python_api import approx
 from _pytest.reports import CollectReport
 from _pytest.reports import TestReport
 
@@ -414,6 +415,26 @@ class TestReportSerialization:
         result = pytester.runpytest_subprocess(".")
         result.stdout.fnmatch_lines(["E   *Error: No module named 'unknown'"])
         result.stdout.no_fnmatch_line("ERROR  - *ConftestImportFailure*")
+
+    def test_report_timestamps_match_duration(self, pytester: Pytester, mock_timing):
+        reprec = pytester.inline_runsource(
+            """
+            import pytest
+            from _pytest import timing
+            @pytest.fixture
+            def fixture_():
+                timing.sleep(5)
+                yield
+                timing.sleep(5)
+            def test_1(fixture_): timing.sleep(10)
+        """
+        )
+        reports = reprec.getreports("pytest_runtest_logreport")
+        assert len(reports) == 3
+        for report in reports:
+            data = report._to_json()
+            loaded_report = TestReport._from_json(data)
+            assert loaded_report.stop - loaded_report.start == approx(report.duration)
 
 
 class TestHooks:


### PR DESCRIPTION
TestReport objects stored only the information about stage duration. This is not enough to correlate pytest stages with external events. Timestamps are already there in CallInfo. They just needed to be propagated to TestReport objects, so that they can be read when TestRerports are exported externally (for example with --reportlog option)

TODO later, it's just a draft.
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
